### PR TITLE
Fixes the screen flipping on DirectX

### DIFF
--- a/Assets/Shaders/AtmosphericScattering.shader
+++ b/Assets/Shaders/AtmosphericScattering.shader
@@ -254,6 +254,9 @@ Shader "Hidden/AtmosphericScattering"
 			float4 fragDir(v2f i) : COLOR0
 			{
 				float2 uv = i.uv.xy;
+#ifdef UNITY_UV_STARTS_AT_TOP
+				uv.y = 1.0 - uv.y;
+#endif
 				float depth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, uv);
 				float linearDepth = Linear01Depth(depth);
 

--- a/Assets/Shaders/AtmosphericScattering.shader
+++ b/Assets/Shaders/AtmosphericScattering.shader
@@ -257,7 +257,7 @@ Shader "Hidden/AtmosphericScattering"
 #ifdef UNITY_UV_STARTS_AT_TOP
 				uv.y = 1.0 - uv.y;
 #endif
-				float depth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, uv);
+				float depth = SAMPLE_DEPTH_TEXTURE(_CameraDepthTexture, i.uv.xy);
 				float linearDepth = Linear01Depth(depth);
 
 				float3 wpos = i.wpos;


### PR DESCRIPTION
UV Y coordinates are reversed on DX-like platforms, this prevents the screen from flipping upside down when in DirectX.